### PR TITLE
add revision to blazer port for 77

### DIFF
--- a/net/blazer/Makefile
+++ b/net/blazer/Makefile
@@ -3,6 +3,7 @@
 COMMENT =		Backblaze B2 command line tool
 
 VERSION=		0.4.8
+REVISION=		0
 DISTNAME =		blazer-${VERSION}.tar.gz
 EXTRACT_SUFX=
 PKGNAME=		blazer-${VERSION}


### PR DESCRIPTION
This is the same version of blazer but for OpenBSD 7.7 is targeting a newer version of restclient-cpp which has a different abi. Thus it needs to the `p0` to definitely overwrite the existing binaries on an upgraded system.